### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is an embedded firmware monorepo (FLUX) for the clectric.diy synth DIY community targeting the AE Modular format. There are no web servers, databases, or runtime services — only cross-compilation toolchains for bare-metal microcontrollers.
+
+### Repo structure (two independent hardware modules)
+
+| Module | Platform | Toolchain | Build entry point |
+|--------|----------|-----------|-------------------|
+| **Spark** | Daisy Seed (STM32H750 / Cortex-M7) | `arm-none-eabi-gcc` + Make | `spark/cpp/ci/build_libs.sh` then `make` in each project dir |
+| **Nexus** | ATmega4809-A (Arduino) | `arduino-cli` + `arduino:megaavr` core | `nexus/ino/build.sh <variant>` |
+
+### Building Spark firmware
+
+1. Submodules must be initialized: `git submodule update --init --recursive`
+2. Build libraries first: `bash spark/cpp/ci/build_libs.sh`
+3. Build individual projects: `make -C spark/cpp/filters`, `make -C spark/cpp/effects`, etc.
+4. The `oscillators` project may overflow FLASH with certain toolchain versions — this is a pre-existing code size issue, not an environment problem.
+
+### Building Nexus firmware
+
+- `cd nexus/ino && bash build.sh all` builds all three variants (router, lunetta, sequencer).
+- Variants can be built individually: `bash build.sh router`, `bash build.sh lunetta`, `bash build.sh sequencer`.
+- Required Arduino libraries (U8g2, Adafruit GFX Library, Adafruit SSD1306) must be installed via `arduino-cli lib install`.
+
+### Coding guidelines
+
+See `.github/copilot-instructions.md` for comprehensive coding standards, naming conventions, and philosophy. Key points: beginner-first code style, Nexus-specific terminology canon, and modular design patterns.
+
+### No lint/test framework
+
+This repo has no formal linter or test runner. "Testing" means successful cross-compilation for the target platforms. The build scripts serve as the primary verification mechanism.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions for the FLUX firmware monorepo.

## What's included

- Repo structure overview (Spark + Nexus modules)
- Build instructions for both toolchains (ARM GCC for Spark, arduino-cli for Nexus)
- Known issues (oscillators FLASH overflow)
- Coding guideline references
- Note about absence of formal lint/test framework

## Environment Setup Verification

All firmware targets were successfully cross-compiled:

**Spark (Daisy Seed / STM32H750):**
- `filters` — built successfully (103 KB binary)
- `effects` — built successfully (104 KB binary)
- `oscillators` — pre-existing FLASH overflow (956 bytes over limit)

**Nexus (ATmega4809 / Arduino):**
- `router` — built successfully (43% flash, 32% RAM)
- `lunetta` — built successfully (43% flash, 32% RAM)
- `sequencer` — built successfully (43% flash, 32% RAM)

[env_setup_output.log](https://cursor.com/agents/bc-f4ab7818-e386-4419-b2ff-6048755538dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_setup_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4ab7818-e386-4419-b2ff-6048755538dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4ab7818-e386-4419-b2ff-6048755538dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

